### PR TITLE
修复 `Leancloud` API `/post` 获取到的友链个数与显示个数不同导致的前端报错

### DIFF
--- a/api/leancloudapi.py
+++ b/api/leancloudapi.py
@@ -213,7 +213,7 @@ def query_post(link, num, rule):
         "author": author,
         "link": link,
         "avatar": avatar,
-        "article_num": article_num
+        "article_num": num # 详情见229行，取的是前num个元素，这里要显示一致，否则会前端触发报错
     }
 
     if num < 0 or num > min(article_num, 1000):

--- a/api/leancloudapi.py
+++ b/api/leancloudapi.py
@@ -209,15 +209,14 @@ def query_post(link, num, rule):
     if not author:
         return {"message": "not found"}
     article_num = len(article_data_init)
+    if num < 0 or num > min(article_num, 1000):
+        num = min(article_num, 1000)
     api_json['statistical_data'] = {
         "author": author,
         "link": link,
         "avatar": avatar,
         "article_num": num # 详情见229行，取的是前num个元素，这里要显示一致，否则会前端触发报错
     }
-
-    if num < 0 or num > min(article_num, 1000):
-        num = min(article_num, 1000)
     if rule != "created" and rule != "updated":
         return {"message": "rule error, please use 'created'/'updated'"}
     article_data_init.sort(key=lambda x: x[rule], reverse=True)

--- a/api/leancloudapi.py
+++ b/api/leancloudapi.py
@@ -215,7 +215,7 @@ def query_post(link, num, rule):
         "author": author,
         "link": link,
         "avatar": avatar,
-        "article_num": num # 详情见229行，取的是前num个元素，这里要显示一致，否则会前端触发报错
+        "article_num": num
     }
     if rule != "created" and rule != "updated":
         return {"message": "rule error, please use 'created'/'updated'"}


### PR DESCRIPTION
见 `228` 行，取的是前 `num` 个元素

https://github.com/Rock-Candy-Tea/hexo-circle-of-friends/blob/70cbb3661739432fd7a3236af23c4839dc664fa2/api/leancloudapi.py#L229

而上文的 `article_num` 显示的数值不一致，会在 `点击头像时` 引发前端报错

https://github.com/Rock-Candy-Tea/hexo-circle-of-friends/blob/70cbb3661739432fd7a3236af23c4839dc664fa2/api/leancloudapi.py#L212-L217

详情见此 API : 
https://hexo-circle-of-friends-6byyqjphz-zkeq.vercel.app/post?num=2&link=https://icodeq.com

返回结果：
```json
{
  "statistical_data": {
    "author": "ZkeqのCode日志",
    "link": "https://coding.maylove.pub",
    "avatar": "https://ik.imagekit.io/zkeq/Avatar.jpg",
    "article_num": 5
  },
  "article_data": [
    {
      "title": "MySQL | Having子句的使用",
      "link": "https://coding.maylove.pub/2022/0282b7cb84cb/",
      "created": "2022-04-27",
      "updated": "2022-04-27",
      "floor": 1
    },
    {
      "title": "MySQL | 分组查询的应用",
      "link": "https://coding.maylove.pub/2022/d1bdc0d653b0/",
      "created": "2022-04-27",
      "updated": "2022-04-27",
      "floor": 2
    }
  ]
}
```

其中的 article_num 为 `5` ，而返回的列表仅有 `2` 个元素，这会引发前端报错
```js
Uncaught (in promise) TypeError: Cannot read properties of undefined (reading 'link')
    at loadFcircleShow (fcircle-beta.js?__WB_REVISION__=91f4105bdb56c379dddf47b215925d60:1:4429)
    at fcircle-beta.js?__WB_REVISION__=91f4105bdb56c379dddf47b215925d60:1:10612
```

![15](https://user-images.githubusercontent.com/62864752/167420401-abf340c3-08ea-49c4-bbe7-757269e61d91.png)


详情见其他人部署的
```
https://guole.fun/moments/
```

修复后的：
```
https://icodeq.com/fcircle/
```

`https://fcircle.icodeq.com/post?num=2&link=https://blog.zytllt.cn`
```json
{
  "statistical_data": {
    "author": "An Wen",
    "link": "https://blog.zytllt.cn",
    "avatar": "https://ik.imagekit.io/zkeq/friends/f5.png",
    "article_num": 2
  },
  "article_data": [
    {
      "title": "bing壁纸自动更新",
      "link": "https://blog.zytllt.cn/239",
      "created": "2022-05-09",
      "updated": "2022-05-09",
      "floor": 1
    },
    {
      "title": "更安全的登录方式！苹果、谷歌、微软三巨头支持无密码技术",
      "link": "https://blog.zytllt.cn/236",
      "created": "2022-05-06",
      "updated": "2022-05-06",
      "floor": 2
    }
  ]
}
```